### PR TITLE
Release Version 5.0.1

### DIFF
--- a/.github/workflows/DevelopmentDPC.yml
+++ b/.github/workflows/DevelopmentDPC.yml
@@ -1,0 +1,60 @@
+
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: Development DPC
+
+on:
+  push:
+    branches: [ "Development" ]
+  pull_request:
+    branches: [ "Development" ]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Debug]
+
+    runs-on: windows-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: AOVPNDPC.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Update Version Details
+      shell: pwsh
+      run: './DPCManagement/Scripts/Set-VersionNumber.ps1'
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    - name: Restore NuGet Packages
+      run: nuget restore $env:Solution_Name
+
+    # Restore the application to populate the obj folder with RuntimeIdentifiers
+    - name: Restore the application
+      run: msbuild $env:Solution_Name "/t:restore;rebuild" /p:Configuration=Debug /property:Platform=x64 /property:RuntimeIdentifier=win-x64
+
+    - name: Run VSTest
+      run:  '& "$(vswhere -property installationPath)\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" "*Tests\bin\x64\*\*Tests.dll" /TestCaseFilter:"TestCategory=Basic" '
+
+    - name: Upload Installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: DPC Installer
+        path: DPCInstaller/bin/x64/Debug/DPC.msi
+

--- a/DPCInstaller/ADMX/en-US/DPC.adml
+++ b/DPCInstaller/ADMX/en-US/DPC.adml
@@ -86,7 +86,7 @@
       <string id="Proxy_PAC">PAC File</string>
       <string id="Proxy_Manual">Proxy Server</string>
       <string id="CAT_DPCCategory">DPC Client</string>
-      <string id="CAT_DPCCategory_Help">DPC Client Help Text</string>
+      <string id="CAT_DPCCategory_Help">DPC Client Configuration Options</string>
       <string id="CAT_DPCCategory_UserTunnel">User Tunnel Settings</string>
       <string id="CAT_DPCCategory_UserTunnel_Help">Settings relating to the User Tunnel Profile</string>
       <string id="CAT_DPCCategory_UserBackupTunnel">Backup User Tunnel Settings</string>

--- a/DPCInstaller/ADMX/en-US/DPC.adml
+++ b/DPCInstaller/ADMX/en-US/DPC.adml
@@ -155,7 +155,7 @@ When this entry isn't specified DNS resolution is provided by the VPN server
 
 'Value Name' should be the DNS Name
 
-'Value' should be the DNS Servers (or left empty to exclude)
+'Value' should be the DNS Servers (or left empty to exclude). Where you can't leave a value empty use '&lt;EMPTY&gt;' to indicate that the value should be empty
 
 Examples:
   Specify specific DNS servers for contoso.com domain:
@@ -163,6 +163,7 @@ Examples:
 
   Use local DNS for public Website:
   www.contoso.com | (No Value)
+  www.contoso.com | &lt;EMPTY&gt;
 </string>
       <string id="DPCCategory_DNSSuffix">Optional - Specify DNS Suffix List</string>
       <string id="DPCCategory_DNSSuffix_Help">List of all DNS Suffixes used within the organization, the first entry becomes the primary search suffix</string>
@@ -345,11 +346,12 @@ When a Forced Tunnel configuration is enabled this setting is ignored
 
 'Value Name' should be the route to include
 
-'Value' is an optional comment
+'Value' is an optional comment. Where you can't leave a value empty use '&lt;EMPTY&gt;' to indicate that the value should be empty
 
 Examples:
 192.168.0.0/16 | Internal Client Ranges
 10.0.0.0/8 | (No Value)
+10.0.0.0/8 | &lt;EMPTY&gt;
 172.16.2.1 | DC01
 </string>
       <string id="DPCCategory_UserTunnel_DNSRouteList">Optional - Allowed Routes from DNS</string>
@@ -367,10 +369,11 @@ When a Forced Tunnel configuration is enabled this setting is ignored
 
 'Value Name' should be the route to include
 
-'Value' is an optional comment
+'Value' is an optional comment. Where you can't leave a value empty use '&lt;EMPTY&gt;' to indicate that the value should be empty
 
 Examples:
 www.bbc.co.uk | (No Value)
+www.bbc.co.uk |  | &lt;EMPTY&gt;
 www.myhr.com | HR System
 		</string>
       <string id="DPCCategory_MachineTunnel_RouteList">Required - Allowed Routes</string>
@@ -380,11 +383,12 @@ This list defines all of the IP ranges which will be sent down the device VPN, t
 
 'Value Name' should be the route to include
 
-'Value' is an optional comment
+'Value' is an optional comment. Where you can't leave a value empty use '&lt;EMPTY&gt;' to indicate that the value should be empty
 
 Examples:
 192.168.0.0/16 | Internal Client Ranges
 10.0.0.0/8 | (No Value)
+10.0.0.0/8 | &lt;EMPTY&gt;
 172.16.2.1 | DC01
       </string>
       <string id="DPCCategory_RouteListExclude">Optional - Excluded Routes</string>
@@ -392,13 +396,13 @@ Examples:
 
 'Value Name' should be the route to exclude
 
-'Value' is an optional comment
+'Value' is an optional comment. Where you can't leave a value empty use '&lt;EMPTY&gt;' to indicate that the value should be empty
 
 Examples:
 192.168.0.0/16 | Internal Client Ranges
 10.0.0.0/8 | (No Value)
+10.0.0.0/8 | &lt;EMPTY&gt;
 172.16.2.1 | DC01
-
 </string>
       <string id="DPCCategory_MachineTunnel_MachineEKU">Optional - Machine Certificate EKU Filter</string>
       <string id="DPCCategory_MachineTunnel_MachineEKU_Help">Filter the list of certificates allowed to by used for authenticating to the VPN to these specific OIDs.

--- a/DPCInstaller/DPCService.wxs
+++ b/DPCInstaller/DPCService.wxs
@@ -1,98 +1,118 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-  <?include ProductVersion.wxi?>
-  <Package Name="AOVPN Dynamic Profile Configurator" Language="1033" Version="$(ProductVersion)" Manufacturer="D'Arcy Services Ltd" UpgradeCode="{337717CB-121A-4606-9979-A6B25120F66E}" InstallerVersion="200">
+	<?include ProductVersion.wxi?>
+	<Package Name="AOVPN Dynamic Profile Configurator" Language="1033" Version="$(ProductVersion)" Manufacturer="D'Arcy Services Ltd" UpgradeCode="{337717CB-121A-4606-9979-A6B25120F66E}" InstallerVersion="200">
 
-    <SummaryInformation Manufacturer="D'Arcy Services Ltd" />
-    <Icon Id="Icon" SourceFile="$(DPCService.ProjectDir)\Assets\Icon.ico" />
+		<SummaryInformation Manufacturer="D'Arcy Services Ltd" />
+		<Icon Id="Icon" SourceFile="$(DPCService.ProjectDir)\Assets\Icon.ico" />
 
-    <!--Set Add/Remove ICON-->
-    <Property Id="ARPPRODUCTICON" Value="Icon" />
+		<!--Set Add/Remove ICON-->
+		<Property Id="ARPPRODUCTICON" Value="Icon" />
 
-    <!--Configure Install UI-->
-    <!--Set the License EULA source File-->
-    <WixVariable Id="WixUILicenseRtf" Value="Assets/EULA.rtf" />
-    <WixVariable Id="WixUIDialogBmp" Value="Assets/Dialog.bmp" />
-    <WixVariable Id="WixUIBannerBmp" Value="Assets/Banner.bmp" />
-    <!--Get the Install Location-->
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+		<!--Configure Install UI-->
+		<!--Set the License EULA source File-->
+		<WixVariable Id="WixUILicenseRtf" Value="Assets/EULA.rtf" />
+		<WixVariable Id="WixUIDialogBmp" Value="Assets/Dialog.bmp" />
+		<WixVariable Id="WixUIBannerBmp" Value="Assets/Banner.bmp" />
+		<!--Get the Install Location-->
+		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
-    <!--Start PrePackaged UI Set which shows EULA and asks for Install Location-->
-    <ui:WixUI Id="WixUI_InstallDir" />
+		<!--Start PrePackaged UI Set which shows EULA and asks for Install Location-->
+		<ui:WixUI Id="WixUI_InstallDir" />
 
-    <!-- AllowSameVersionUpgrades is set to no as the service currently uses major and minor from installer then dynamically
+		<!-- AllowSameVersionUpgrades is set to no as the service currently uses major and minor from installer then dynamically
     sets the build number (*).  While this isn't perfect it avoids potential downgrade issues and a warning on build-->
-    <MajorUpgrade AllowSameVersionUpgrades="no" DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features." />
+		<MajorUpgrade AllowSameVersionUpgrades="no" DowngradeErrorMessage="A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features." />
 
-    <!--Embed the data cab (default cab1.cab) into the MSI so there is only a single file-->
-    <MediaTemplate EmbedCab="yes" />
+		<!--Embed the data cab (default cab1.cab) into the MSI so there is only a single file-->
+		<MediaTemplate EmbedCab="yes" />
 
-    <Feature Id="ProductFeature" Title="DPCInstaller" Level="1">
-      <ComponentGroupRef Id="EventLogs" />
-      <ComponentGroupRef Id="DependencyFiles" />
-      <ComponentGroupRef Id="WindowsService" />
-      <ComponentGroupRef Id="AncillaryFiles" />
-      <ComponentGroupRef Id="PDAncillaryFiles" />
-      <ComponentGroupRef Id="RegistryInstallNotice" />
-    </Feature>
-  </Package>
+		<Feature Id="ProductFeature" Title="DPCInstaller" Level="1">
+			<ComponentGroupRef Id="EventLogs" />
+			<ComponentGroupRef Id="DependencyFiles" />
+			<ComponentGroupRef Id="WindowsService" />
+			<ComponentGroupRef Id="AncillaryFiles" />
+			<ComponentGroupRef Id="PDAncillaryFiles" />
+			<ComponentGroupRef Id="RegistryInstallNotice" />
+			<?if $(var.Configuration) = Debug ?>
+				<ComponentGroupRef Id="DebugSymbols" />
+			<?endif?>
+		</Feature>
+	</Package>
 
-  <Fragment>
-    <ComponentGroup Id="EventLogs" Directory="INSTALLFOLDER">
-      <Component Id="etwManifest.dll">
-        <File Id="etwManifest.dll" KeyPath="yes" Source="$(DPCService.TargetDir)\DPCService.DPC-AOVPN-DPCService.etwManifest.dll" />
-      </Component>
-      <Component Id="etwManifest.man">
-        <File Id="etwManifest.man" KeyPath="yes" Source="$(DPCService.TargetDir)\DPCService.DPC-AOVPN-DPCService.etwManifest.man">
-          <util:EventManifest MessageFile="[#etwManifest.dll]" ResourceFile="[#etwManifest.dll]"></util:EventManifest>
-        </File>
-      </Component>
-    </ComponentGroup>
-  </Fragment>
+	<Fragment>
+		<ComponentGroup Id="EventLogs" Directory="INSTALLFOLDER">
+			<Component Id="etwManifest.dll">
+				<File Id="etwManifest.dll" KeyPath="yes" Source="$(DPCService.TargetDir)\DPCService.DPC-AOVPN-DPCService.etwManifest.dll" />
+			</Component>
+			<Component Id="etwManifest.man">
+				<File Id="etwManifest.man" KeyPath="yes" Source="$(DPCService.TargetDir)\DPCService.DPC-AOVPN-DPCService.etwManifest.man">
+					<util:EventManifest MessageFile="[#etwManifest.dll]" ResourceFile="[#etwManifest.dll]"></util:EventManifest>
+				</File>
+			</Component>
+		</ComponentGroup>
+	</Fragment>
 
-  <Fragment>
-    <ComponentGroup Id="DependencyFiles" Directory="INSTALLFOLDER">
-      <Component Id="DPCLibrary">
-        <File Id="___var.DPCService.TargetDir_DPCLibrary.dll" KeyPath="yes" Source="$(DPCService.TargetDir)DPCLibrary.dll" />
-      </Component>
+	<Fragment>
+		<ComponentGroup Id="DebugSymbols" Directory="INSTALLFOLDER">
+			<Component Id="DPCLibraryDebugSymbols">
+				<File Id="___var.DPCService.TargetDir_DPCLibrary.pdb" KeyPath="yes" Source="$(DPCService.TargetDir)DPCLibrary.pdb" />
+			</Component>
 
-      <Component Id="NewtonsoftJson">
-        <File Id="___var.DPCService.TargetDir_Newtonsoft.Json.dll" KeyPath="yes" Source="$(DPCService.TargetDir)Newtonsoft.Json.dll" />
-      </Component>
-    </ComponentGroup>
-  </Fragment>
+			<Component Id="DPCServiceDebugSymbols">
+				<File Id="___var.DPCService.TargetDir_DPCService.pdb" KeyPath="yes" Source="$(DPCService.TargetDir)DPCService.pdb" />
+			</Component>
+		</ComponentGroup>
+	</Fragment>
 
-  <Fragment>
-    <ComponentGroup Id="WindowsService" Directory="INSTALLFOLDER">
-      <Component Id="ProductComponent">
-        <File Id="___var.DPCService.TargetPath_" Source="$(DPCService.TargetPath)" />
-        <ServiceInstall Name="DPCService" DisplayName="AOVPN DPC Service" Description="AOVPN DPC Service" Start="auto" Type="ownProcess" ErrorControl="normal" Vital="yes">
-          <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" />
-			<ServiceDependency Id="EventLog" />
-        </ServiceInstall>
-        <!--Start the service after installation-->
-        <ServiceControl Id="StartDPCService" Name="DPCService" Start="install" Wait="no" />
-        <!--Stop the service before installation to allow a new version to overwrite-->
-        <ServiceControl Id="StopDPCService" Name="DPCService" Stop="both" Wait="yes" />
-        <!--Remove the service on uninstall, otherwise the service still exists until the device reboots-->
-        <ServiceControl Id="RemoveDPCService" Name="DPCService" Remove="uninstall" Wait="yes" />
-      </Component>
-    </ComponentGroup>
-  </Fragment>
+	<Fragment>
+		<ComponentGroup Id="DependencyFiles" Directory="INSTALLFOLDER">
+			<Component Id="DPCLibrary">
+				<File Id="___var.DPCService.TargetDir_DPCLibrary.dll" KeyPath="yes" Source="$(DPCService.TargetDir)DPCLibrary.dll" />
+			</Component>
 
-  <Fragment>
-    <ComponentGroup Id="AncillaryFiles">
-      <Component Id="README" Directory="INSTALLFOLDER">
-        <File Id="README.html" KeyPath="yes" Source="Assets/README.html" />
-      </Component>
-		<!-- Copy ADMX files to Install Folder -->
-      <Component Id="ADMX" Directory="ADMXDir">
-        <File Id="dpc.admx" KeyPath="yes" Source="ADMX\dpc.admx" />
-      </Component>
-      <Component Id="ADML" Directory="ADMLDir">
-        <File Id="dpc.adml" KeyPath="yes" Source="ADMX\en-US\dpc.adml" />
-      </Component>
-    </ComponentGroup>
-  </Fragment>
+			<Component Id="NewtonsoftJson">
+				<File Id="___var.DPCService.TargetDir_Newtonsoft.Json.dll" KeyPath="yes" Source="$(DPCService.TargetDir)Newtonsoft.Json.dll" />
+			</Component>
+		</ComponentGroup>
+	</Fragment>
+
+	<Fragment>
+		<ComponentGroup Id="WindowsService" Directory="INSTALLFOLDER">
+			<Component Id="ProductComponent">
+				<File Id="___var.DPCService.TargetPath_" Source="$(DPCService.TargetPath)" />
+				<ServiceInstall Name="DPCService" DisplayName="AOVPN DPC Service" Description="AOVPN DPC Service" Start="auto" Type="ownProcess" ErrorControl="normal" Vital="yes">
+					<util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" />
+					<ServiceDependency Id="EventLog" />
+				</ServiceInstall>
+				<!--Start the service after installation-->
+				<ServiceControl Id="StartDPCService" Name="DPCService" Start="install" Wait="no" />
+				<!--Stop the service before installation to allow a new version to overwrite-->
+				<ServiceControl Id="StopDPCService" Name="DPCService" Stop="both" Wait="yes" />
+				<!--Remove the service on uninstall, otherwise the service still exists until the device reboots-->
+				<ServiceControl Id="RemoveDPCService" Name="DPCService" Remove="uninstall" Wait="yes" />
+			</Component>
+		</ComponentGroup>
+	</Fragment>
+
+	<Fragment>
+		<ComponentGroup Id="AncillaryFiles">
+			<Component Id="README" Directory="INSTALLFOLDER">
+				<File Id="README.html" KeyPath="yes" Source="Assets/README.html" />
+			</Component>
+
+			<!-- Copy ADMX files to Install Folder -->
+			<Component Id="ADMX" Directory="ADMXDir">
+				<File Id="dpc.admx" KeyPath="yes" Source="ADMX\dpc.admx" />
+			</Component>
+			<Component Id="ADML" Directory="ADMLDir">
+				<File Id="dpc.adml" KeyPath="yes" Source="ADMX\en-US\dpc.adml" />
+			</Component>
+		</ComponentGroup>
+	</Fragment>
+
+	<Fragment>
+
+	</Fragment>
 
 	<Fragment>
 		<!-- Copy ADMX files to C:\Windows\PolicyDefinitions Folder -->
@@ -106,29 +126,29 @@
 		</ComponentGroup>
 	</Fragment>
 
-  <Fragment>
-    <ComponentGroup Id="RegistryInstallNotice" Directory="TARGETDIR">
-      <Component Id="DPCInstalledRegistry">
-        <RegistryKey Root="HKLM" Key="Software\DPC\DPCClient" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
-          <RegistryValue Type="integer" Name="DPCInstalled" Value="1" KeyPath="yes" />
-          <RegistryValue Type="string" Name="DPCVersion" Value="$(ProductVersion)" />
-        </RegistryKey>
-      </Component>
-    </ComponentGroup>
-  </Fragment>
+	<Fragment>
+		<ComponentGroup Id="RegistryInstallNotice" Directory="TARGETDIR">
+			<Component Id="DPCInstalledRegistry">
+				<RegistryKey Root="HKLM" Key="Software\DPC\DPCClient" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no">
+					<RegistryValue Type="integer" Name="DPCInstalled" Value="1" KeyPath="yes" />
+					<RegistryValue Type="string" Name="DPCVersion" Value="$(ProductVersion)" />
+				</RegistryKey>
+			</Component>
+		</ComponentGroup>
+	</Fragment>
 
 	<Fragment>
-			<!-- Define Program Files Installation Directory -->
-			<StandardDirectory Id="ProgramFiles64Folder">
-					<Directory Id="INSTALLFOLDER" Name="!(bind.property.ProductName)" />
-			</StandardDirectory>
-			<!-- Define C:\Windows\PolicyDefinitions Folder for copying ADMX Files into -->
-			<StandardDirectory Id="WindowsFolder">
-				<Directory Id="PolicyDefinitions" Name="PolicyDefinitions">
-					<Directory Id="PDADMLDir" Name="en-US" />
-				</Directory>
-			</StandardDirectory>
-		</Fragment>
+		<!-- Define Program Files Installation Directory -->
+		<StandardDirectory Id="ProgramFiles64Folder">
+			<Directory Id="INSTALLFOLDER" Name="!(bind.property.ProductName)" />
+		</StandardDirectory>
+		<!-- Define C:\Windows\PolicyDefinitions Folder for copying ADMX Files into -->
+		<StandardDirectory Id="WindowsFolder">
+			<Directory Id="PolicyDefinitions" Name="PolicyDefinitions">
+				<Directory Id="PDADMLDir" Name="en-US" />
+			</Directory>
+		</StandardDirectory>
+	</Fragment>
 
 	<Fragment>
 		<DirectoryRef Id="INSTALLFOLDER">

--- a/DPCInstaller/ProductVersion.wxi
+++ b/DPCInstaller/ProductVersion.wxi
@@ -1,3 +1,3 @@
 ﻿<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <?define ProductVersion=5.0.0?>
+  <?define ProductVersion=5.0.1?>
 </Include>

--- a/DPCLibrary/Models/ProfileUpdate.cs
+++ b/DPCLibrary/Models/ProfileUpdate.cs
@@ -11,7 +11,7 @@ namespace DPCLibrary.Models
         private string profileXML;
         public string ProfileName { get; set; }
         public string OldProfileName { get; set; }
-        public ProfileType ProfileType { get; set; } //Only really used for events to not strictly required to be accurate
+        public ProfileType ProfileType { get; set; }
         public string ProfileXML
         {
             get => profileXML;

--- a/DPCLibrary/Utils/AccessRegistry.cs
+++ b/DPCLibrary/Utils/AccessRegistry.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 //Registry Key = Folder
 //Registry Value = Named Element
@@ -429,7 +430,10 @@ namespace DPCLibrary.Utils
                 if (valueType == RegistryValueKind.String)
                 {
                     string resultValue = (string)regKey.GetValue(subKey);
-                    returnTable.Add(subKey, resultValue.Replace("\0",""));
+                    resultValue = resultValue.Trim();
+                    resultValue = resultValue.Replace("\0", "");
+                    resultValue = Regex.Replace(resultValue, "<EMPTY>", "", RegexOptions.IgnoreCase);
+                    returnTable.Add(subKey, resultValue);
                 }
                 //Skip any non string values
             }

--- a/DPCLibrary/Utils/AccessRegistry.cs
+++ b/DPCLibrary/Utils/AccessRegistry.cs
@@ -122,13 +122,13 @@ namespace DPCLibrary.Utils
             {
                 string[] result = (string[])regKey.GetValue(regValue);
                 regKey.Close();
-                return string.Join("\n",result);
+                return string.Join("\n",result).Replace("\0","");
             }
             else if (valueType == RegistryValueKind.String)
             {
                 string result = (string)regKey.GetValue(regValue);
                 regKey.Close();
-                return result;
+                return result.Replace("\0", "");
             }
             else if (valueType == RegistryValueKind.ExpandString)
             {
@@ -139,7 +139,7 @@ namespace DPCLibrary.Utils
                 {
                     result = Environment.ExpandEnvironmentVariables(result);
                 }
-                return result;
+                return result.Replace("\0", "");
             }
             else
             {
@@ -193,16 +193,17 @@ namespace DPCLibrary.Utils
             {
                 string[] result = (string[])regKey.GetValue(value);
                 regKey.Close();
+                result = result.Select(x => x.Replace("\0", "")).ToArray(); //Remove Null chars from strings in the array as these can cause issues and should never exist
                 return result.ToList();
             }
             else if (valueType == RegistryValueKind.String)
             {
                 string result = (string)regKey.GetValue(value);
+                regKey.Close();
                 IList<string> returnList = new List<string>
                 {
-                    result
+                    result.Replace("\0","")
                 };
-                regKey.Close();
                 return returnList;
             }
             else
@@ -427,7 +428,8 @@ namespace DPCLibrary.Utils
                 RegistryValueKind valueType = regKey.GetValueKind(subKey);
                 if (valueType == RegistryValueKind.String)
                 {
-                    returnTable.Add(subKey, (string)regKey.GetValue(subKey));
+                    string resultValue = (string)regKey.GetValue(subKey);
+                    returnTable.Add(subKey, resultValue.Replace("\0",""));
                 }
                 //Skip any non string values
             }

--- a/DPCLibrary/Utils/MiniDump.cs
+++ b/DPCLibrary/Utils/MiniDump.cs
@@ -19,11 +19,22 @@ namespace DPCLibrary.Utils
             return Write(miniDumpNaming.GetMiniDumpName(), MiniDumpTypes.MiniDumpWithFullMemory);
         }
 
+        public static string WriteReturnName()
+        {
+            string miniDumpName = miniDumpNaming.GetMiniDumpName();
+            if (Write(miniDumpName, MiniDumpTypes.MiniDumpWithFullMemory))
+            {
+                return miniDumpName;
+            }
+
+            return null;
+        }
+
         public static bool Write(string fileName)
         {
             return Write(fileName, MiniDumpTypes.MiniDumpWithFullMemory);
         }
-        public static bool Write(string fileName, MiniDumpTypes dumpTyp)
+        public static bool Write(string fileName, MiniDumpTypes dumpType)
         {
             using (var fs = new System.IO.FileStream(fileName, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.None))
             {
@@ -35,7 +46,7 @@ namespace DPCLibrary.Utils
                   NativeMethods.GetCurrentProcess(),
                   NativeMethods.GetCurrentProcessId(),
                   fs.SafeFileHandle.DangerousGetHandle(),
-                  (uint)dumpTyp,
+                  (uint)dumpType,
                   ref exp,
                   IntPtr.Zero,
                   IntPtr.Zero);

--- a/DPCLibrary/Utils/VPNProfileCreator.cs
+++ b/DPCLibrary/Utils/VPNProfileCreator.cs
@@ -819,6 +819,12 @@ namespace DPCLibrary.Utils
         {
             ValidateParameters();
 
+            if(ValidateFailed())
+            {
+                //We know that there are issues so severe that the profile won't be installed so don't attempt to generate as this can cause crashes which won't show the validation warnings
+                return;
+            }
+
             ProfileString.Clear();
 
             if (!string.IsNullOrWhiteSpace(OverrideXML))

--- a/DPCLibrary/Utils/VPNProfileCreator.cs
+++ b/DPCLibrary/Utils/VPNProfileCreator.cs
@@ -868,12 +868,12 @@ namespace DPCLibrary.Utils
 
                 if (DisableUIEditButton)
                 {
-                    writer.WriteElementString("DisableAdvancedOptionsEditButton", (DisableUIEditButton).ToString().ToLowerInvariant());
+                    writer.WriteElementString("DisableAdvancedOptionsEditButton", DisableUIEditButton.ToString().ToLowerInvariant());
                 }
 
                 if (DisableUIDisconnectButton)
                 {
-                    writer.WriteElementString("DisableDisconnectButton", (DisableUIDisconnectButton).ToString().ToLowerInvariant());
+                    writer.WriteElementString("DisableDisconnectButton", DisableUIDisconnectButton.ToString().ToLowerInvariant());
                 }
 
                 if (ProfileType == ProfileType.Machine)

--- a/DPCLibraryTests/DPCLibraryTests.csproj
+++ b/DPCLibraryTests/DPCLibraryTests.csproj
@@ -84,10 +84,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.6.1</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.6.1</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DPCLibraryTests/DPCLibraryTests.csproj
+++ b/DPCLibraryTests/DPCLibraryTests.csproj
@@ -84,10 +84,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.7.0</Version>
+      <Version>3.7.3</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.7.0</Version>
+      <Version>3.7.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DPCLibraryTests/VPNProfileCreatorTests.cs
+++ b/DPCLibraryTests/VPNProfileCreatorTests.cs
@@ -462,7 +462,7 @@ namespace DPCLibraryTests
                             "somewherelse.partner"
                         };
 
-            CreateBasicUserProfileInRegistry(ProfileType.UserBackup);
+            CreateBasicUserProfileInRegistry(profileType);
             AccessRegistry.SaveMachineData("DNSSuffix", SuffixList, RegistrySettings.GetProfileOffset(profileType));
             AccessRegistry.SaveMachineData("TrustedNetworks", SuffixList, RegistrySettings.GetProfileOffset(profileType));
 
@@ -745,16 +745,7 @@ namespace DPCLibraryTests
             Assert.IsTrue(pro.ValidateFailed());
             Assert.IsFalse(string.IsNullOrWhiteSpace(pro.GetValidationFailures()));
             Assert.IsTrue(string.IsNullOrWhiteSpace(pro.GetValidationWarnings()));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(profile));
-
-            ValidateXMLText(profile, "Servers", standardServerName);
-            ValidateXMLText(profile, "RoutingPolicyType", "SplitTunnel");
-            ValidateXMLText(profile, "UserMethod", "Eap");
-            ValidateNPSList(profile, standardNPSServerList);
-            ValidateRootThumbprintList(profile, standardRootCAList);
-            ValidateIssuingThumbprintList(profile, standardIssuingCAList);
-            ValidateXMLTextIsMissing(profile, "EKUName");
-            ValidateXMLTextIsMissing(profile, "EKUOID");
+            Assert.IsTrue(string.IsNullOrWhiteSpace(profile)); //Profile should not generate
         }
 
         [DataTestMethod]
@@ -808,7 +799,6 @@ namespace DPCLibraryTests
             AccessRegistry.SaveMachineData(RegistrySettings.LimitEKU, true, RegistrySettings.GetProfileOffset(profileType));
             AccessRegistry.SaveMachineData(RegistrySettings.EKUOID, EKUOID, RegistrySettings.GetProfileOffset(profileType));
 
-
             VPNProfileCreator pro = new VPNProfileCreator(profileType, false);
             pro.LoadFromRegistry();
 
@@ -822,16 +812,7 @@ namespace DPCLibraryTests
             Assert.IsTrue(pro.ValidateFailed());
             Assert.IsFalse(string.IsNullOrWhiteSpace(pro.GetValidationFailures()));
             Assert.IsTrue(string.IsNullOrWhiteSpace(pro.GetValidationWarnings()));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(profile));
-
-            ValidateXMLText(profile, "Servers", standardServerName);
-            ValidateXMLText(profile, "RoutingPolicyType", "SplitTunnel");
-            ValidateXMLText(profile, "UserMethod", "Eap");
-            ValidateNPSList(profile, standardNPSServerList);
-            ValidateRootThumbprintList(profile, standardRootCAList);
-            ValidateIssuingThumbprintList(profile, standardIssuingCAList);
-            ValidateXMLTextIsMissing(profile, "EKUName");
-            ValidateXMLTextIsMissing(profile, "EKUOID");
+            Assert.IsTrue(string.IsNullOrWhiteSpace(profile)); //Profile should not generate
         }
 
         [DataTestMethod]
@@ -1395,7 +1376,7 @@ namespace DPCLibraryTests
             ValidateXMLTextIsMissing(profile, "TrustedNetworkDetection");
 
             VPNProfile profileObj = new CSPProfile(profile, pro.GetProfileName());
-            Assert.AreEqual(standardUserRouteList.Count + 2, profileObj.RouteList.Count);
+            Assert.AreEqual(standardUserRouteList.Count + 3, profileObj.RouteList.Count);
             Assert.AreEqual(0, profileObj.RouteList.Where(r => r.ExclusionRoute).ToList().Count);
         }
 
@@ -1503,7 +1484,7 @@ namespace DPCLibraryTests
             ValidateXMLTextIsMissing(profile, "TrustedNetworkDetection");
 
             VPNProfile profileObj = new CSPProfile(profile, pro.GetProfileName());
-            Assert.AreEqual(standardUserRouteList.Count + 2, profileObj.RouteList.Where(r => !r.ExclusionRoute).ToList().Count);
+            Assert.AreEqual(standardUserRouteList.Count + 3, profileObj.RouteList.Where(r => !r.ExclusionRoute).ToList().Count);
             Assert.AreEqual(0, profileObj.RouteList.Where(r => r.ExclusionRoute).ToList().Count);
         }
 

--- a/DPCManagement/Scripts/Clear-NullFromGPO.ps1
+++ b/DPCManagement/Scripts/Clear-NullFromGPO.ps1
@@ -1,0 +1,61 @@
+﻿
+#Description
+#Migrates settings from PowerON DPC to DPC Version 5+
+param
+(
+    [Parameter(Mandatory)]
+    [String]
+    $GPOName
+)
+
+#Please run on a Domain Controller or another server with the Group Policy Management RSAT Tools installed
+Import-Module -Name GroupPolicy -ErrorAction Stop
+
+#Check that GPO Exists
+Get-GPO -Name $GPOName -ErrorAction Stop | Out-Null
+
+Function Copy-GPORegistryKey
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $KeyPath,
+        [Parameter(Mandatory)]
+        [String]
+        $GPOName,
+        [Parameter()]
+        [String]
+        $Indent
+    )
+
+    $AllValues = Get-GPRegistryValue -Name $GPOName -Key $KeyPath
+
+    foreach ($Value in $AllValues)
+    {
+        if ($null -eq $Value.Type)
+        {
+            #Empty type means that this value is a subkey
+            Write-Output "$($Indent)Checking Settings for $($Value.KeyPath.Split("\")[-1])"
+            Copy-GPORegistryKey -KeyPath $Value.FullKeyPath -GPOName $GPOName -Indent ($Indent + "`t")
+            continue
+        }
+
+        Write-Output "$($Indent)Checking $($Value.ValueName)"
+
+        if ($Value.Value.GetType() -ne [int])
+        {
+            $Data = $Value.Value.Replace("`0","") 
+        }
+        else
+        {
+            $Data = $Value.Value
+        }
+
+        Set-GPRegistryValue -Name $GPOName -Value $Data -ValueName $Value.ValueName -Type $Value.Type -Key $Value.FullKeyPath | Out-Null
+    }
+}
+
+Copy-GPORegistryKey -KeyPath "HKEY_LOCAL_MACHINE\Software\Policies\DPC\DPCClient" -GPOName $GPOName
+
+Write-Output "Script Complete"

--- a/DPCManagement/Scripts/Clear-NullFromRegistry.ps1
+++ b/DPCManagement/Scripts/Clear-NullFromRegistry.ps1
@@ -1,0 +1,37 @@
+﻿$RegList = @("HKLM:\SOFTWARE\Policies\DPC\DPCClient","HKLM:\SOFTWARE\DPC\DPCClient")
+
+Function Clear-NullChars
+{
+    param(
+        [string]
+        $RegKey
+    )
+    Write-Output "Checking $RegKey"
+    $RegKey = $RegKey.Replace("HKEY_LOCAL_MACHINE","HKLM:")
+
+    $Item = Get-Item -Path $RegKey
+
+    foreach ($Value in $Item.Property)
+    {
+        Write-Output "Checking $Value"
+        $Data = Get-ItemPropertyValue -Path $RegKey -Name $Value
+        if ($Data.GetType() -eq [int]) {continue}
+        $SanitisedData = $Data.Replace("`0","")
+        if ($Data.Length -ne $SanitisedData.Length) #Null is not compared but does change the length of the string
+        {
+            Write-Warning "Null Found, Fixing..."
+            Set-ItemProperty -Path $RegKey -Name $Value -Value $SanitisedData
+        }
+    }
+
+    $SubKeys = Get-ChildItem -Path $RegKey
+    foreach ($Key in $SubKeys)
+    {
+        Clear-NullChars -RegKey $Key.Name
+    }
+}
+
+foreach ($RegKey in $RegList)
+{
+    Clear-NullChars -RegKey $RegKey
+}

--- a/DPCManagement/Scripts/Get-DPCLogs.ps1
+++ b/DPCManagement/Scripts/Get-DPCLogs.ps1
@@ -3,9 +3,9 @@
 #Gathers as much data about the DPC Agent and System State as possible to assist with troubleshooting DPC related issues
 
 Param (
-    [Parameter(Mandatory=$true)]
+    [Parameter()]
     [string]
-    $Name,
+    $FileName="DPCLog",
     [Switch]
     $DebugLogs
 )
@@ -52,7 +52,7 @@ try
         throw "Script must be run as an administrator"
     }
 
-    $ZipPath = Join-Path -Path $env:TEMP -ChildPath "DPCLog.zip"
+    $ZipPath = Join-Path -Path $env:TEMP -ChildPath "$FileName.zip"
 
     Write-Output "Getting Hostname"
     $env:COMPUTERNAME | Out-File (Join-Path -Path $SavePath -ChildPath "SystemInfo\HostName.txt")
@@ -148,7 +148,9 @@ try
         $Drive = $Drive + ":"
     }
 
-    $UserDirectories = Get-ChildItem -Path (Join-Path -Path $Drive -ChildPath "Users")
+    $UserDir = $Env:USERPROFILE
+
+    $UserDirectories = Split-Path -Path $UserDir -Parent
     foreach ($UserDirectory in $UserDirectories)
     {
         $UserPBKLocation = Join-Path -Path $UserDirectory.fullName -ChildPath "AppData\Roaming\Microsoft\Network\Connections\Pbk"

--- a/DPCManagement/Scripts/Get-DPCLogs.ps1
+++ b/DPCManagement/Scripts/Get-DPCLogs.ps1
@@ -148,9 +148,9 @@ try
         $Drive = $Drive + ":"
     }
 
-    $UserDir = $Env:USERPROFILE
+    $UserDir = Split-Path -Path $Env:USERPROFILE -Parent
 
-    $UserDirectories = Split-Path -Path $UserDir -Parent
+    $UserDirectories =  Get-ChildItem -Path $UserDir
     foreach ($UserDirectory in $UserDirectories)
     {
         $UserPBKLocation = Join-Path -Path $UserDirectory.fullName -ChildPath "AppData\Roaming\Microsoft\Network\Connections\Pbk"

--- a/DPCManagement/Scripts/Get-DPCLogs.ps1
+++ b/DPCManagement/Scripts/Get-DPCLogs.ps1
@@ -224,6 +224,7 @@ try
     Write-Output "Checking for Memory Dumps"
     $MemoryDumpList = @()
     $MemoryDumpList += Get-ChildItem -Path (Join-Path -Path $env:SystemDrive -ChildPath "Windows\Temp") -Filter DPCService-*.dmp
+    $MemoryDumpList += Get-ChildItem -Path (Join-Path -Path $env:SystemDrive -ChildPath "Windows\SystemTemp") -Filter DPCService-*.dmp
     if ($MemoryDumpList.Count -gt 0)
     {
         Write-Output "Copying Memory Dumps"

--- a/DPCManagement/Scripts/Migrate-DPCConfig.ps1
+++ b/DPCManagement/Scripts/Migrate-DPCConfig.ps1
@@ -61,7 +61,17 @@ Function Copy-GPORegistryKey
         }
 
         Write-Output "$($Indent)Copying over $($Value.ValueName)"
-        Set-GPRegistryValue -Name $NewGPOName -Value $Value.Value -ValueName $Value.ValueName -Type $Value.Type -Key $Value.FullKeyPath.Replace("PowerONPlatforms\AOVPNDPCClient","DPC\DPCClient") | Out-Null
+
+        if ($Value.Value.GetType() -ne [int])
+        {
+            $Data = $Value.Value.Replace("`0","") 
+        }
+        else
+        {
+            $Data = $Value.Value
+        }
+
+        Set-GPRegistryValue -Name $NewGPOName -Value $Data -ValueName $Value.ValueName -Type $Value.Type -Key $Value.FullKeyPath.Replace("PowerONPlatforms\AOVPNDPCClient","DPC\DPCClient") | Out-Null
     }
 }
 

--- a/DPCManagement/Scripts/Run-AsSYSTEM.ps1
+++ b/DPCManagement/Scripts/Run-AsSYSTEM.ps1
@@ -1,7 +1,7 @@
-﻿$PSExecPath = "C:\Program Files\WindowsApps\Microsoft.SysinternalsSuite_2024.6.1.0_x64__8wekyb3d8bbwe\Tools\PsExec.exe"
-$VSPath = "C:\Program Files\Microsoft Visual Studio\2022\enterprise"
+﻿$PSExecPath = "C:\Program Files\WindowsApps\Microsoft.SysinternalsSuite_2024.12.0.0_x64__8wekyb3d8bbwe\Tools\PsExec.exe"
+$VSPath = "C:\Program Files\Microsoft Visual Studio\2022\community"
 $MSBuildpath = "$VSPath\MSBuild\Current\Bin\msbuild.exe"
-$SolutionRootPath = "C:\source\AOVPN DPC"
+$SolutionRootPath = "C:\source\DPC"
 $Project = "DPCService"
 
 if(-NOT (Test-path -Path $PSExecPath))

--- a/DPCManagement/Scripts/Run-TestsAsSYSTEM.ps1
+++ b/DPCManagement/Scripts/Run-TestsAsSYSTEM.ps1
@@ -1,4 +1,4 @@
-$PSExecPath = "C:\Program Files\WindowsApps\Microsoft.SysinternalsSuite_2024.7.0.0_x64__8wekyb3d8bbwe\Tools\PsExec.exe"
+$PSExecPath = "C:\Program Files\WindowsApps\Microsoft.SysinternalsSuite_2024.12.0.0_x64__8wekyb3d8bbwe\Tools\PsExec.exe"
 $VSPath = "C:\Program Files\Microsoft Visual Studio\2022\Community"
 $VSTestPath = "$VSPath\Common7\IDE\Extensions\TestPlatform\vstest.console.exe"
 $MSBuildpath = "$VSPath\MSBuild\Current\Bin\msbuild.exe"

--- a/DPCService/Core/DPCService.cs
+++ b/DPCService/Core/DPCService.cs
@@ -130,7 +130,7 @@ namespace DPCService.Core
             {
                 if (SharedData == null || SharedData.DumpOnException)
                 {
-                    MiniDump.Write();
+                    AppSettings.WriteMiniDumpAndLog();
                 }
 
                 DPCServiceEvents.Log.GenericErrorMessage("Service Start", e.Message, e.StackTrace);
@@ -174,7 +174,7 @@ namespace DPCService.Core
             {
                 if (SharedData == null || SharedData.DumpOnException)
                 {
-                    MiniDump.Write();
+                    AppSettings.WriteMiniDumpAndLog();
                 }
                 //Attempt to close the service down
                 ServiceStatus serviceStatus = new ServiceStatus

--- a/DPCService/Core/ProfileMonitor.cs
+++ b/DPCService/Core/ProfileMonitor.cs
@@ -152,6 +152,16 @@ namespace DPCService.Core
                         AppSettings.WriteMiniDumpAndLog();
                     }
 
+                    if (profile.ValidateFailed())
+                    {
+                        DPCServiceEvents.Log.ProfileGenerationErrors(LogProfileName, profile.GetValidationFailures());
+                    }
+
+                    if (profile.ValidateWarnings())
+                    {
+                        DPCServiceEvents.Log.ProfileGenerationWarnings(LogProfileName, profile.GetValidationWarnings());
+                    }
+
                     DPCServiceEvents.Log.ProfileCreationFailed(ProfileName, e.Message, e.StackTrace);
 #if DEBUG
                     DPCServiceEvents.Log.ProfileCreationFailedDebug(ProfileName, e.ToString());

--- a/DPCService/Core/ProfileMonitor.cs
+++ b/DPCService/Core/ProfileMonitor.cs
@@ -81,6 +81,7 @@ namespace DPCService.Core
                 try
                 {
                     profile.LoadFromRegistry(); //Reload settings from registry to check for any Group Policy Updates
+                    bool newName = UpdateProfileName(); //Update Name as early as possible to enable better logging of profile names
                     profile.Generate();
                     string savePath = null;
                     try
@@ -95,8 +96,6 @@ namespace DPCService.Core
                     {
                         DPCServiceEvents.Log.UpdateToSaveProfileToDisk(LogProfileName, e.Message, savePath);
                     }
-
-                    bool newName = UpdateProfileName();
 
                     bool genFailed = profile.ValidateFailed();
 
@@ -154,6 +153,9 @@ namespace DPCService.Core
                     }
 
                     DPCServiceEvents.Log.ProfileCreationFailed(ProfileName, e.Message, e.StackTrace);
+#if DEBUG
+                    DPCServiceEvents.Log.ProfileCreationFailedDebug(ProfileName, e.ToString());
+#endif
                 }
                 finally
                 {
@@ -277,7 +279,7 @@ namespace DPCService.Core
         {
             string newProfileName = profile.GetProfileName();
 
-            if (newProfileName == null)
+            if (string.IsNullOrWhiteSpace(newProfileName))
             {
                 LogProfileName = DefaultProfileName();
                 return false;

--- a/DPCService/Core/ProfileMonitor.cs
+++ b/DPCService/Core/ProfileMonitor.cs
@@ -150,7 +150,7 @@ namespace DPCService.Core
                 {
                     if (SharedData.DumpOnException)
                     {
-                        MiniDump.Write();
+                        AppSettings.WriteMiniDumpAndLog();
                     }
 
                     DPCServiceEvents.Log.ProfileCreationFailed(ProfileName, e.Message, e.StackTrace);

--- a/DPCService/Models/SharedData.cs
+++ b/DPCService/Models/SharedData.cs
@@ -307,7 +307,7 @@ namespace DPCService.Models
                     {
                         if (DumpOnException)
                         {
-                            MiniDump.Write();
+                            AppSettings.WriteMiniDumpAndLog();
                         }
 
                         //Some types of failure start the tattoo process before failing so need cleaning up

--- a/DPCService/Models/SharedData.cs
+++ b/DPCService/Models/SharedData.cs
@@ -351,7 +351,8 @@ namespace DPCService.Models
             //Track rasMan restarts over more than 1 refresh so that if the tunnels to shut rasMan can be restarted at that point
             if (rasManRestartNeeded)
             {
-                if (ConnectedVPNList.Count == 0)
+                ManagedProfile deviceTunnelProfile = ManagedProfileList.Where(p => p.ProfileType == ProfileType.Machine).FirstOrDefault();
+                if (ConnectedVPNList.Count == 0 || (ConnectedVPNList.Count == 1 && deviceTunnelProfile != null && ConnectedVPNList.Contains(deviceTunnelProfile.ProfileName)))
                 {
                     DPCServiceEvents.Log.RestartingRasManService();
 

--- a/DPCService/Utils/AppSettings.cs
+++ b/DPCService/Utils/AppSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DPCLibrary.Utils;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -11,6 +12,16 @@ namespace DPCService.Utils
             Assembly assembly = Assembly.GetExecutingAssembly();
             FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
             return new Version(fileVersionInfo.ProductVersion);
+        }
+
+        public static void WriteMiniDumpAndLog()
+        {
+            string miniDumpName = MiniDump.WriteReturnName();
+            if (string.IsNullOrWhiteSpace(miniDumpName))
+            {
+                DPCServiceEvents.Log.MiniDumpSaveFailed();
+            }
+            DPCServiceEvents.Log.MiniDumpSaved(miniDumpName);
         }
     }
 }

--- a/DPCService/Utils/DPCServiceEvents.cs
+++ b/DPCService/Utils/DPCServiceEvents.cs
@@ -345,6 +345,10 @@ namespace DPCService.Utils
         public void RasManRestartNeeded() { WriteEvent(1216); }
         [Event(1217, Message = "Restart RasMan Service Requested", Level = EventLevel.Informational, Channel = EventChannel.Operational)]
         public void RestartRasManServiceRequested() { WriteEvent(1217); }
+        [Event(1218, Message = "MiniDump saved to: {0}", Level = EventLevel.Error, Channel = EventChannel.Operational)]
+        public void MiniDumpSaved(string miniDumpPath) { WriteEvent(1218, miniDumpPath); }
+        [Event(1219, Message = "MiniDump Failed to Save", Level = EventLevel.Error, Channel = EventChannel.Operational)]
+        public void MiniDumpSaveFailed() { WriteEvent(1219); }
         #endregion 1100-1299 Profile Monitoring
 
         #region 2000-2099 Profile Monitoring

--- a/DPCService/Utils/DPCServiceEvents.cs
+++ b/DPCService/Utils/DPCServiceEvents.cs
@@ -349,6 +349,8 @@ namespace DPCService.Utils
         public void MiniDumpSaved(string miniDumpPath) { WriteEvent(1218, miniDumpPath); }
         [Event(1219, Message = "MiniDump Failed to Save", Level = EventLevel.Error, Channel = EventChannel.Operational)]
         public void MiniDumpSaveFailed() { WriteEvent(1219); }
+        [Event(1220, Message = "Unexpected failure in profile creation process: \nProfile Name: {0}\nError:\n{1}", Level = EventLevel.Error, Channel = EventChannel.Operational)]
+        public void ProfileCreationFailedDebug(string profileName, string exception) { WriteEvent(1220, profileName, exception); }
         #endregion 1100-1299 Profile Monitoring
 
         #region 2000-2099 Profile Monitoring

--- a/DPCService/Utils/DPCServiceEvents.cs
+++ b/DPCService/Utils/DPCServiceEvents.cs
@@ -145,11 +145,11 @@ namespace DPCService.Utils
         public void ProfileGenerationWarnings(string profileName, string errors) { WriteEvent(1107, profileName, errors); }
         [Event(1108, Message = "Profile {0} (Type {1}) was not added.\nError: \n{2} \nStackTrace: \n{3}", Level = EventLevel.Error, Channel = EventChannel.Operational)]
         public void AddProfileFailed(string profileName, ProfileType profileType, string errors, string stackTrace) { WriteEvent(1108, profileName, profileType, errors, stackTrace); }
-        [Event(1109, Message = "Unexpected failure in profile creation process: \n{0} \nError: {1} \nStackTrace: {2}", Level = EventLevel.Error, Channel = EventChannel.Operational)]
+        [Event(1109, Message = "Unexpected failure in profile creation process: \nProfile Name: {0}\nError: {1}\nStackTrace: {2}", Level = EventLevel.Error, Channel = EventChannel.Operational)]
         public void ProfileCreationFailed(string profileName, string errors, string stackTrace) { WriteEvent(1109, profileName, errors, stackTrace); }
         [Event(1110, Message = "Unable to save profile to disk: {0} \n Errors: {1} \n Location: {2}", Level = EventLevel.Warning, Channel = EventChannel.Operational)]
         public void UpdateToSaveProfileToDisk(string profileName, string errors, string location) { WriteEvent(1110, profileName, errors, location); }
-        [Event(1111, Message = "Unable to load Registry Value {0} due to Reason: \n {1}", Level = EventLevel.Warning, Channel = EventChannel.Operational)]
+        [Event(1111, Message = "Unable to load Registry Value {0} due to Reason: \n{1}", Level = EventLevel.Warning, Channel = EventChannel.Operational)]
         public void UnableToReadRegistry(string regValue, string errors) { WriteEvent(1111, regValue, errors); }
         [Event(1112, Message = "Removing Profile {0}", Level = EventLevel.Informational, Channel = EventChannel.Debug)]
         public void ProfileDebugRemoveProfile(string profileName) { WriteEvent(1112, profileName); }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Unfortunately there is no easy way to copy an existing Configuration policy and 
 
 # Release Notes
 
+## Version 5.0.1
+
+- Ignore null values in registry settings
+- Added support for <EMPTY> value in ADMX settings which have optional values
+- Allow RasMan to restart if the Device Tunnel is still operational
+- Added additional events for troubleshooting
+- Debug installer now installs Debug Symbols for additional information
+
 ## Version 5.0.0
 
 - Removed Product Key and Trial Subsystems

--- a/ServiceIntergrationTests/ServiceIntegrationTests.csproj
+++ b/ServiceIntergrationTests/ServiceIntegrationTests.csproj
@@ -85,13 +85,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>3.1.16</Version>
+      <Version>3.1.18</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.6.1</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.6.1</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ServiceIntergrationTests/ServiceIntegrationTests.csproj
+++ b/ServiceIntergrationTests/ServiceIntegrationTests.csproj
@@ -88,10 +88,10 @@
       <Version>3.1.18</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.7.0</Version>
+      <Version>3.7.3</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.7.0</Version>
+      <Version>3.7.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Release Notes

- Ignore null values in registry settings
- Added support for <EMPTY> value in ADMX settings which have optional values
- Allow RasMan to restart if the Device Tunnel is still operational
- Added additional events for troubleshooting
- Debug installer now installs Debug Symbols for additional information


Also updated the Log collection script