### PR TITLE
Improve CIDR validation logic for IPv4 addresses

### DIFF
--- a/DPCLibrary/Utils/Validate.cs
+++ b/DPCLibrary/Utils/Validate.cs
@@ -190,9 +190,9 @@ namespace DPCLibrary.Utils
                 return false;
             }
 
-            if (!IPv4(SplitCIDR[0]))
+            if (!(SplitCIDR[0] == "0.0.0.0" || IPv4(SplitCIDR[0])))
             {
-                //Front part isn't a valid address
+                //Front part isn't 0.0.0.0 or a valid address
                 return false;
             }
 


### PR DESCRIPTION
Valid CIDRs that start with 0.0.0.0 are being filtered out by the library.

Line 135 of the IPv4 validation rejects 0.0.0.0 (with a note saying that it is only valid in CIDR), but the CIDR function is just trying to validate the CIDR as an IP.

https://github.com/ld0614/DPC/blob/c7bcd9fa208ac0093263be0d9b4e81957b1a144e/DPCLibrary/Utils/Validate.cs#L135

This PR enhances the validation logic to allow CIDRs that start with 0.0.0.0/x